### PR TITLE
feature/starship: add Bash auto-loader

### DIFF
--- a/features/src/starship/devcontainer-feature.json
+++ b/features/src/starship/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "id": "starship",
   "name": "starship",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "containerEnv": {
     "LANG": "C.UTF-8"
   }

--- a/features/src/starship/install.sh
+++ b/features/src/starship/install.sh
@@ -54,3 +54,13 @@ rm -f $PACKAGE
 # endregion
 
 # endregion
+
+# region Shell integration
+
+mkdir -p /etc/bashrc.d
+
+cat <<EOF >>/etc/bashrc.d/starship
+eval "\$(starship init bash)"
+EOF
+
+# endregion


### PR DESCRIPTION
Install Starship Bash initializer in /etc/bashrc.d. If image/bash is enabled, then all files in /etc/bashrc.d will be auto-loaded. Otherwise, it's a no op.