### PR TITLE
feature/bash: auto-load custom bashrc addons

### DIFF
--- a/features/src/bash/devcontainer-feature.json
+++ b/features/src/bash/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "id": "bash",
   "name": "bash",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "containerEnv": {
     "LANG": "C.UTF-8"
   },

--- a/features/src/bash/install.sh
+++ b/features/src/bash/install.sh
@@ -79,3 +79,21 @@ chmod +x $BIN_DIR/shfmt
 # endregion
 
 # endregion
+
+# region Shell integration
+
+mkdir -p /etc/bashrc.d
+
+cat <<EOF >>/etc/bash.bashrc
+if [ -d /etc/bashrc.d ]; then
+  for i in /etc/bashrc.d/*; do
+    if [ -r "\$i" ]; then
+      # shellcheck disable=SC1090
+      . "\$i"
+    fi
+  done
+  unset i
+fi
+EOF
+
+# endregion


### PR DESCRIPTION
Auto load any file in `/etc/bashrc.d`.
This allows other features to add new Bash add-ons as needed. If Bash is the shell of interest to the user, then all the add-ons are auto-loaded.